### PR TITLE
Adjust header font size to match main text

### DIFF
--- a/src/css/settings.css
+++ b/src/css/settings.css
@@ -10,7 +10,8 @@ body {
 }
 
 .line-number,
-.line-text {
+.line-text,
+h3 {
 	font-family: FONT_FAMILY;
 	font-size: FONT_SIZE;
 	line-height: LINE_SPACINGem;


### PR DESCRIPTION
    
    - The document header font size in the generated HTML (in my webbrowser) is uncomfortably larger than the main text, of which I believe results in a visually jarring effect and inefficient use of paper space.
    - Modified settings.css to apply the same font size to the header as is used for the line numbers and main text (which can be set via settings).
    - This is just a quick fix; I think a more robust solution would allow manual setting of the header font size, and maybe even the font itself (this is my first commit to an extension ever, I am not skilled enough for doing this properly).