### PR TITLE
Fix inconsistent line height on line wrap

### DIFF
--- a/src/css/settings.css
+++ b/src/css/settings.css
@@ -15,5 +15,6 @@ h3 {
 	font-family: FONT_FAMILY;
 	font-size: FONT_SIZE;
 	line-height: LINE_SPACINGem;
-	padding-bottom: 3px;
+	padding-bottom: 0px;
+	padding-top: 0px; /* Table cell has inherited 1px of padding */
 }

--- a/src/print-session.ts
+++ b/src/print-session.ts
@@ -174,10 +174,12 @@ export class PrintSession {
 				case "settings.css":
 					const printConfig = vscode.workspace.getConfiguration("print");
 					const editorConfig = vscode.workspace.getConfiguration("editor");
+					const fontPixelHeight = printConfig.fontSize.replace("pt", "") / (.75); // Point to pixels
+					const lineHeightPadding = ((fontPixelHeight + 4) / fontPixelHeight) - 1; // Adjust line height to add four pixels of padding (3px above, 1px below)
 					const css = settingsCss
 						.replace("FONT_FAMILY", editorConfig.fontFamily)
 						.replace("FONT_SIZE", printConfig.fontSize)
-						.replace("LINE_SPACING", printConfig.lineSpacing)
+						.replace("LINE_SPACING", (printConfig.lineSpacing + lineHeightPadding).toFixed(4))
 						.replace("TAB_SIZE", editorConfig.tabSize)
 					response.writeHead(200, {
 						"Content-Type": "text/css; charset=utf-8",


### PR DESCRIPTION
Lines that were wrapped were too close together. However, if you adjust the line-height by the right ratio, you can get the padding without specifying `padding-bottom` and get the same line spacing for all lines.

Before:

![test1](https://github.com/PDConSec/vsc-print/assets/69168929/b0447b21-5c50-4f87-952d-48773afc98d0)

After:

![test2](https://github.com/PDConSec/vsc-print/assets/69168929/15dda81c-fcbc-4e6c-b07f-a3e3bfa9a13c)
