### PR TITLE
Remove font-family except for body

### DIFF
--- a/src/css/default-markdown.css
+++ b/src/css/default-markdown.css
@@ -5,23 +5,17 @@ body {
 	font-size: 14pt;
 }
 
-p {
-	font-family: serif;
-}
-
 h1,
 h2,
 h3,
 h4,
 h5,
 h6 {
-	font-family: sans-serif;
 	page-break-after: avoid;
 	page-break-inside: avoid;
 }
 
 table {
-	font-family: sans-serif;
 	width: 100%;
 	border-collapse: collapse;
 }


### PR DESCRIPTION
This allows for custom stylesheets to specify the font just in the body without having to set it for many other elements.